### PR TITLE
Fix the build failure due to the vhiveease/fcuvm_dev version

### DIFF
--- a/tools/devtool
+++ b/tools/devtool
@@ -73,7 +73,7 @@
 # Development container image (name:tag)
 # This should be updated whenever we upgrade the development container.
 # (Yet another step on our way to reproducible builds.)
-DEVCTR_IMAGE="vhiveease/fcuvm_dev:latest"
+DEVCTR_IMAGE="vhiveease/fcuvm_dev:v28"
 
 # Naming things is hard
 MY_NAME="Firecracker $(basename "$0")"


### PR DESCRIPTION
## Reason for This PR

I found that the build failure discussed in #1  
is due to the wrong version of vhiveease/fcuvm_dev.

`/tools/devtools` uses the `vhiveease/fcuvm_dev:latest` which was actually [pushed 2 years ago](https://hub.docker.com/r/vhiveease/fcuvm_dev/tags).
The latest `vhiveease/fcuvm_dev` is `vhiveease/fcuvm_dev:v28` which was pushed a year ago.

## Description of Changes

I changed `vhiveease/fcuvm_dev` version from `latest` to `v28`.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
